### PR TITLE
Fix for always generating double cache records for parameter update jobs.

### DIFF
--- a/WebApplication/ClientApp/src/actions/parametersActions.js
+++ b/WebApplication/ClientApp/src/actions/parametersActions.js
@@ -67,12 +67,16 @@ export const resetParameters = (projectId, parameters) => {
  *           "\"Small\""
  *           ],
  *           "value": "\"Small\"",
- *           "unit": "Text"
+ *           "unit": "Text",
+ *           "label": "Size"
+ *           "readonly": false
  *       },
  *       "JawOffset": {
  *           "values": [],
  *           "value": "10 mm",
- *           "unit": "mm"
+ *           "unit": "mm",
+ *           "label": "Jaw Offset",
+ *           "readonly": false
  *       }
  * }
  */
@@ -134,6 +138,8 @@ export function formatParameters(clientParameters) {
         const value = quoteValues ? quote(param.value) : param.value;
 
         obj[param.name] = {
+            label: param.label ? param.label : null,
+            readonly: param.readonly,
             value: value,
             unit: param.units ? param.units : null,
             values: values

--- a/WebApplication/ClientApp/src/actions/parametersActions.test.js
+++ b/WebApplication/ClientApp/src/actions/parametersActions.test.js
@@ -202,7 +202,9 @@ describe('fetchParameters', () => {
                         name: 'WrenchSz',
                         value: 'Small',
                         units: 'Text',
-                        allowedValues: ['Large', 'Medium', 'Small']
+                        allowedValues: ['Large', 'Medium', 'Small'],
+                        label: "Size",
+                        readonly: false
                     }
                 ];
 
@@ -210,7 +212,9 @@ describe('fetchParameters', () => {
                     WrenchSz: {
                         value: '"Small"',
                         unit: 'Text',
-                        values: ['"Large"', '"Medium"', '"Small"']
+                        values: ['"Large"', '"Medium"', '"Small"'],
+                        label: "Size",
+                        readonly: false
                     }
                 };
 


### PR DESCRIPTION
Fixed the issue where we always generated double cache records due to our initial hash being wrong. This was caused by not providing all the parameter details to the cache generator.