### PR TITLE
fix the behaviour of Project Switcher

### DIFF
--- a/WebApplication/ClientApp/src/components/projectSwitcher.js
+++ b/WebApplication/ClientApp/src/components/projectSwitcher.js
@@ -28,15 +28,15 @@ export class ProjectSwitcher extends Component {
 
     constructor(props) {
         super(props);
-        this.onProjectChange = this.onProjectChange.bind(this);
+        this.onProjectClick = this.onProjectClick.bind(this);
     }
 
     componentDidMount() {
         this.props.fetchProjects();
     }
 
-    onProjectChange(data) {
-        const id = data.project.id;
+    onProjectClick(event) {
+        const id = event.target.innerHTML;
         this.props.updateActiveProject(id);
         // mark drawing as not valid if any available
         this.props.invalidateDrawing();
@@ -49,11 +49,11 @@ export class ProjectSwitcher extends Component {
     render() {
         return (
             <ProjectAccountSwitcher
-                defaultProject={this.props.projectList.activeProjectId}
-                activeProject={null}
+                defaultProject={null}
+                activeProject={this.props.projectList.activeProjectId}
                 projects={this.props.projectList.projects}
                 projectTitle="Projects"
-                onChange={this.onProjectChange}
+                onClick={this.onProjectClick}
             />
         );
     }

--- a/WebApplication/ClientApp/src/components/projectSwitcher.test.js
+++ b/WebApplication/ClientApp/src/components/projectSwitcher.test.js
@@ -51,7 +51,7 @@ describe('components', () => {
     it('should propagate data to proper properties', () => {
       const wrapper = shallow(<ProjectSwitcher {...baseProps} />);
 
-      expect(wrapper.props().defaultProject).toBe(projectList.activeProjectId);
+      expect(wrapper.props().activeProject).toBe(projectList.activeProjectId);
       expect(wrapper.props().projects).toBe(projectList.projects);
       expect(wrapper.props().projectTitle).toBe('Projects');
     });
@@ -71,13 +71,13 @@ describe('components', () => {
       };
 
       const wrapper = shallow(<ProjectSwitcher {...props} />);
-      wrapper.simulate('change', {
-        project : {
-          id: 5
+      wrapper.simulate('click', {
+        target : {
+          innerHTML: "5"
         }
       });
 
-      expect(updateActiveProject).toHaveBeenLastCalledWith(5);
+      expect(updateActiveProject).toHaveBeenLastCalledWith("5");
     });
 
     it('should activate model tab when project changed', () => {
@@ -97,9 +97,9 @@ describe('components', () => {
       };
 
       const wrapper = shallow(<ProjectSwitcher {...props} />);
-      wrapper.simulate('change', {
-        project : {
-          id: 2
+      wrapper.simulate('click', {
+        target : {
+          innerHTML: "2"
         }
       });
 


### PR DESCRIPTION
(it used to stop reacting to project selection from Projects tab once a project has been selected in the combo itself).

Fix based on ProjectAccountSwitcher [documentation ](http://storybook.hig.autodesk.com/?knob-Default%20Project=2&knob-Alignment=left&knob-Variant=body&knob-Placement=top&knob-Project%20List%20Label=Projects&knob-Density=medium-density&knob-Link=https%3A%2F%2Fgithub.com%2FAutodesk%2Fhig&knob-Projects=%5B%7B%22id%22%3A%221%22%2C%22label%22%3A%22Project%201%22%7D%2C%7B%22id%22%3A%222%22%2C%22label%22%3A%22Project%202%22%2C%22image%22%3A%22static%2Fmedia%2Farchitecture.4f58e584.png%22%7D%5D&knob-Font%20Weight=normal&knob-Children=This%20should%20render%20nicely.&knob-Default%20Account=1&knob-Color%20scheme=hig-light-gray&knob-Max%20Height=&knob-Account%20List%20Label=Accounts&knob-Anchor%20Point=bottom-center&knob-Label=Foo&knob-Accounts=%5B%7B%22id%22%3A%221%22%2C%22label%22%3A%22Account%201%22%7D%2C%7B%22id%22%3A%222%22%2C%22label%22%3A%22Account%202%22%2C%22image%22%3A%22static%2Fmedia%2Fdam.4ea811be.png%22%7D%5D&selectedKind=GlobalNav%7CProjectAccountSwitcher&selectedStory=default&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybook%2Factions%2Factions-panel) for controlled vs uncontrolled component and the discussion in slack channel about it's [expected way of use](https://app.slack.com/client/T02NW42JD/C5FLF7R46).