### PR TITLE
Elb disk changes

### DIFF
--- a/AWS-CICD/.ebextensions/change-root-volume-size.config
+++ b/AWS-CICD/.ebextensions/change-root-volume-size.config
@@ -1,0 +1,9 @@
+Resources:
+    AWSEBAutoScalingLaunchConfiguration:
+        Type: AWS::AutoScaling::LaunchConfiguration
+        Properties:
+            BlockDeviceMappings:
+               - DeviceName: /dev/sda1
+                 Ebs:
+                     VolumeSize:
+                        20

--- a/AWS-CICD/.ebextensions/change-root-volume-size.config
+++ b/AWS-CICD/.ebextensions/change-root-volume-size.config
@@ -3,7 +3,7 @@ Resources:
         Type: AWS::AutoScaling::LaunchConfiguration
         Properties:
             BlockDeviceMappings:
-               - DeviceName: /dev/sda1
+               - DeviceName: /dev/xvda1
                  Ebs:
                      VolumeSize:
                         20

--- a/AWS-CICD/.ebextensions/change-root-volume-size.config
+++ b/AWS-CICD/.ebextensions/change-root-volume-size.config
@@ -1,9 +1,4 @@
-Resources:
-    AWSEBAutoScalingLaunchConfiguration:
-        Type: AWS::AutoScaling::LaunchConfiguration
-        Properties:
-            BlockDeviceMappings:
-               - DeviceName: /dev/xvda1
-                 Ebs:
-                     VolumeSize:
-                        20
+option_settings:
+    aws:autoscaling:launchconfiguration:
+        RootVolumeType: gp2
+        RootVolumeSize: "20"

--- a/AWS-CICD/.ebextensions/cronjob.config
+++ b/AWS-CICD/.ebextensions/cronjob.config
@@ -6,7 +6,7 @@ files:
         content: |
             0 23 * * * root /usr/local/bin/remove_old_files.sh
 
-     "/usr/local/bin/remove_old_files.sh":
+    "/usr/local/bin/remove_old_files.sh":
         mode: "000755"
         owner: root
         group: root
@@ -15,6 +15,6 @@ files:
             docker ps -q | xargs docker inspect --format='{{ .State.Pid }}' | xargs -IZ sudo fstrim /proc/Z/root/
             exit 0
 
- commands:
+commands:
     remove_old_cron:
         command: "rm -f /etc/cron.d/*.bak"

--- a/AWS-CICD/.ebextensions/cronjob.config
+++ b/AWS-CICD/.ebextensions/cronjob.config
@@ -1,0 +1,20 @@
+files:
+    "/etc/cron.d/mycron":
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+            0 23 * * * root /usr/local/bin/remove_old_files.sh
+
+     "/usr/local/bin/remove_old_files.sh":
+        mode: "000755"
+        owner: root
+        group: root
+        content: |
+            #!/bin/bash
+            docker ps -q | xargs docker inspect --format='{{ .State.Pid }}' | xargs -IZ sudo fstrim /proc/Z/root/
+            exit 0
+
+ commands:
+    remove_old_cron:
+        command: "rm -f /etc/cron.d/*.bak"

--- a/AWS-CICD/build-specs/buildspec-mig-build.yml
+++ b/AWS-CICD/build-specs/buildspec-mig-build.yml
@@ -13,6 +13,7 @@ phases:
 artifacts:
   files:
     - 'mig/**/*'
+    - 'AWS-CICD/.ebextensions/**/*'
     - 'AWS-CICD/commands-mig.sh'
     - 'AWS-CICD/Dockerfile-mig.image'
     - 'AWS-CICD/build-specs/buildspec-mig-image.yml'

--- a/AWS-CICD/build-specs/buildspec-mig-image.yml
+++ b/AWS-CICD/build-specs/buildspec-mig-image.yml
@@ -24,5 +24,5 @@ phases:
 artifacts:
   files:
     - Dockerrun.aws.json
-    - 'AWS-CICD/.ebextensions/**/*'
+    - '.ebextensions/**/*'
   base-directory: AWS-CICD

--- a/AWS-CICD/build-specs/buildspec-mig-image.yml
+++ b/AWS-CICD/build-specs/buildspec-mig-image.yml
@@ -24,4 +24,5 @@ phases:
 artifacts:
   files:
     - Dockerrun.aws.json
+    - 'AWS-CICD/.ebextensions/**/*'
   base-directory: AWS-CICD


### PR DESCRIPTION
These changes are bringing two new files:
1. increase the size of the hard drive on the deployed machine from 8 GB to 20 GB to satisfy growing LocalCache. 
2. use cron to clear once a day an unused docker storage, which was casing failure of the server in 3 weeks of run.