### PR TITLE
INVGEN-49677 During migration using same localcache folder for all users

### DIFF
--- a/WebApplication/Migration.cs
+++ b/WebApplication/Migration.cs
@@ -73,6 +73,7 @@ namespace MigrationApp
 
       private async Task ScanBucket(List<MigrationJob> adoptJobs, List<MigrationJob> configJobs, string bucketKeyOld)
       {
+         _logger.LogInformation($"Scanning bucket {bucketKeyOld}");
          MigrationBucketKeyProvider bucketProvider;
          ProjectService projectService;
          using (var scope = _serviceScopeFactory.CreateScope())

--- a/WebApplication/MigrationJob.cs
+++ b/WebApplication/MigrationJob.cs
@@ -65,6 +65,8 @@ namespace MigrationApp
          _logger.LogInformation($"{logId}: Generating config for project {projectInfo.Name} in bucket {bucket.BucketKey}");
 
          OssBucket bucketNew = await _userResolver.GetBucketAsync();
+         var storage = await _userResolver.GetProjectStorageAsync(projectInfo.Name);
+         await storage.EnsureAttributesAsync(bucketNew);
 
          try
          {

--- a/WebApplication/State/UserResolver.cs
+++ b/WebApplication/State/UserResolver.cs
@@ -100,17 +100,8 @@ namespace WebApplication.State
         public async Task<string> GetFullUserDir()
         {
             string userDir;
-            if (_profileProvider.IsAuthenticated)
-            {
-                var profile = await _profileProvider.GetProfileAsync();
-
-                // generate dirname to hide Oxygen user ID
-                userDir = Crypto.GenerateHashString("SDRA" + profile.userId);
-            }
-            else
-            {
-                userDir = "_anonymous";
-            }
+            var bucketKey = await _bucketKeyProvider.GetBucketKeyAsync();
+            userDir = Crypto.GenerateHashString("SDRA" + bucketKey);
 
             return Path.Combine(_localCache.LocalRootName, userDir);
         }


### PR DESCRIPTION
- added more loggings
- ensuring localcache gets populated
- changed localchange folder, so it is based on bucketkey rather then user name, since Migration does not work with user names.